### PR TITLE
fix: Add Async Middleware Variants for LangGraph Compatibility (#108)

### DIFF
--- a/vibe/core/engine/langchain_middleware.py
+++ b/vibe/core/engine/langchain_middleware.py
@@ -96,6 +96,18 @@ class ContextWarningMiddleware(AgentMiddleware):
                 )
         return None
 
+    async def abefore_model(
+        self, state: AgentState, runtime: Runtime
+    ) -> dict[str, Any] | None:
+        """Async version of before_model for LangGraph compatibility."""
+        return self.before_model(state, runtime)
+
+    async def aafter_model(
+        self, state: AgentState, runtime: Runtime
+    ) -> dict[str, Any] | None:
+        """Async version of after_model for LangGraph compatibility."""
+        return self.after_model(state, runtime)
+
     def _get_current_token_count(self, state: AgentState) -> int:
         """Get current token count from cumulative tracking.
 
@@ -230,6 +242,18 @@ class PriceLimitMiddleware(AgentMiddleware):
 
         return None
 
+    async def abefore_model(
+        self, state: AgentState, runtime: Runtime
+    ) -> dict[str, Any] | None:
+        """Async version of before_model for LangGraph compatibility."""
+        return self.before_model(state, runtime)
+
+    async def aafter_model(
+        self, state: AgentState, runtime: Runtime
+    ) -> dict[str, Any] | None:
+        """Async version of after_model for LangGraph compatibility."""
+        return self.after_model(state, runtime)
+
 
 class LoggerMiddleware(AgentMiddleware):
     """Log agent execution for observability and debugging.
@@ -265,6 +289,18 @@ class LoggerMiddleware(AgentMiddleware):
             session_id = getattr(runtime, "session_id", "unknown")
             logger.info(f"[SESSION END] Agent session {session_id} completed")
         return None
+
+    async def abefore_agent(
+        self, state: AgentState, runtime: Runtime
+    ) -> dict[str, Any] | None:
+        """Async version of before_agent for LangGraph compatibility."""
+        return self.before_agent(state, runtime)
+
+    async def aafter_agent(
+        self, state: AgentState, runtime: Runtime
+    ) -> dict[str, Any] | None:
+        """Async version of after_agent for LangGraph compatibility."""
+        return self.after_agent(state, runtime)
 
     def _log_model_request(self, request: ModelRequest) -> None:
         """Logs model request details."""


### PR DESCRIPTION
## Summary

This PR implements async middleware variants to prevent `NotImplementedError` crashes when LangGraph calls async versions of middleware hooks. All three middleware classes now have corresponding async methods that delegate to their sync implementations.

## Changes Made

### `vibe/core/engine/langchain_middleware.py`

1. **ContextWarningMiddleware**: Added `abefore_model()` and `aafter_model()`
2. **PriceLimitMiddleware**: Added `abefore_model()` and `aafter_model()`
3. **LoggerMiddleware**: Added `abefore_agent()` and `aafter_agent()`

## Problem Solved

LangGraph defines both sync and async variants for all middleware hooks. When LangGraph called async variants (`abefore_model`, `aafter_model`, etc.) on these middlewares, it raised `NotImplementedError` causing system crashes.

## Implementation Pattern

All async methods delegate to their sync counterparts:
```python
async def abefore_model(self, state: AgentState, runtime: Runtime):
    return self.before_model(state, runtime)
```

This ensures:
- Full async compatibility with LangGraph
- No code duplication
- Consistent behavior between sync and async execution paths

## Testing

- ✅ All 30 existing unit tests pass (`tests/unit/test_langchain_middleware.py`)
- ✅ Verified async methods correctly delegate to sync versions
- ✅ No regressions introduced

## Acceptance Criteria Met

- [x] Implemented `abefore_model()` and `aafter_model()` for `ContextWarningMiddleware`
- [x] Implemented `abefore_model()` and `aafter_model()` for `PriceLimitMiddleware`
- [x] Implemented `abefore_agent()` and `aafter_agent()` for `LoggerMiddleware`
- [x] All async methods delegate to corresponding sync versions
- [x] No `NotImplementedError` raised in async code paths
- [x] Full async compatibility with LangGraph